### PR TITLE
Add CRUD support and admin UI

### DIFF
--- a/warcalendar_backend.py
+++ b/warcalendar_backend.py
@@ -1,5 +1,15 @@
 from fastapi import FastAPI, HTTPException, Depends, Header
-from sqlalchemy import Column, Integer, String, DateTime, Table, ForeignKey, create_engine, and_, or_
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Table,
+    ForeignKey,
+    create_engine,
+    and_,
+    or_,
+)
 from sqlalchemy.orm import relationship, sessionmaker, declarative_base, Session
 from pydantic import BaseModel
 from datetime import datetime
@@ -17,14 +27,16 @@ Base = declarative_base()
 
 # --- Association Table ---
 event_tag_association = Table(
-    'event_tag', Base.metadata,
-    Column('event_id', Integer, ForeignKey('events.id')),
-    Column('tag_id', Integer, ForeignKey('tags.id'))
+    "event_tag",
+    Base.metadata,
+    Column("event_id", Integer, ForeignKey("events.id")),
+    Column("tag_id", Integer, ForeignKey("tags.id")),
 )
+
 
 # --- Models ---
 class Event(Base):
-    __tablename__ = 'events'
+    __tablename__ = "events"
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String, nullable=False)
     type = Column(String, nullable=False)
@@ -37,24 +49,32 @@ class Event(Base):
 
     tags = relationship("Tag", secondary=event_tag_association, back_populates="events")
 
+
 class Tag(Base):
-    __tablename__ = 'tags'
+    __tablename__ = "tags"
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, nullable=False)
 
-    events = relationship("Event", secondary=event_tag_association, back_populates="tags")
+    events = relationship(
+        "Event", secondary=event_tag_association, back_populates="tags"
+    )
+
 
 # --- Pydantic Schemas ---
 class TagBase(BaseModel):
     name: str
 
+
 class TagCreate(TagBase):
     pass
 
+
 class TagRead(TagBase):
     id: int
+
     class Config:
         orm_mode = True
+
 
 class EventBase(BaseModel):
     title: str
@@ -65,20 +85,40 @@ class EventBase(BaseModel):
     image_url: Optional[str] = None
     source_url: Optional[str] = None
 
+
 class EventCreate(EventBase):
     tag_ids: list[int] = []
+
 
 class EventRead(EventBase):
     id: int
     created_at: datetime
     tags: list[TagRead] = []
+
     class Config:
         orm_mode = True
+
+
+class EventUpdate(BaseModel):
+    title: Optional[str] = None
+    type: Optional[str] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    description: Optional[str] = None
+    image_url: Optional[str] = None
+    source_url: Optional[str] = None
+    tag_ids: Optional[list[int]] = None
+
+
+class TagUpdate(TagBase):
+    pass
+
 
 # --- FastAPI App ---
 app = FastAPI()
 
 Base.metadata.create_all(bind=engine)
+
 
 # --- Dependency ---
 def get_db():
@@ -88,9 +128,11 @@ def get_db():
     finally:
         db.close()
 
+
 def verify_api_key(x_api_key: str = Header(...)):
     if x_api_key != API_KEY:
         raise HTTPException(status_code=403, detail="Invalid API Key")
+
 
 # --- Routes ---
 @app.post("/tags/", response_model=TagRead, dependencies=[Depends(verify_api_key)])
@@ -101,9 +143,11 @@ def create_tag(tag: TagCreate, db: Session = Depends(get_db)):
     db.refresh(db_tag)
     return db_tag
 
+
 @app.get("/tags/", response_model=list[TagRead])
 def list_tags(db: Session = Depends(get_db)):
     return db.query(Tag).all()
+
 
 @app.post("/events/", response_model=EventRead, dependencies=[Depends(verify_api_key)])
 def create_event(event: EventCreate, db: Session = Depends(get_db)):
@@ -115,6 +159,7 @@ def create_event(event: EventCreate, db: Session = Depends(get_db)):
     db.refresh(db_event)
     return db_event
 
+
 @app.get("/events/", response_model=list[EventRead])
 def list_events(
     type: Optional[str] = None,
@@ -122,7 +167,7 @@ def list_events(
     active: Optional[bool] = None,
     from_date: Optional[datetime] = None,
     to_date: Optional[datetime] = None,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     query = db.query(Event)
 
@@ -142,3 +187,66 @@ def list_events(
         query = query.join(Event.tags).filter(Tag.name == tag)
 
     return query.all()
+
+
+@app.get("/events/{event_id}", response_model=EventRead)
+def get_event(event_id: int, db: Session = Depends(get_db)):
+    event = db.query(Event).filter(Event.id == event_id).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return event
+
+
+@app.put(
+    "/events/{event_id}",
+    response_model=EventRead,
+    dependencies=[Depends(verify_api_key)],
+)
+def update_event(event_id: int, event: EventUpdate, db: Session = Depends(get_db)):
+    db_event = db.query(Event).filter(Event.id == event_id).first()
+    if not db_event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    if event.tag_ids is not None:
+        tags = db.query(Tag).filter(Tag.id.in_(event.tag_ids)).all()
+        db_event.tags = tags
+
+    for field, value in event.dict(exclude={"tag_ids"}, exclude_none=True).items():
+        setattr(db_event, field, value)
+
+    db.commit()
+    db.refresh(db_event)
+    return db_event
+
+
+@app.delete("/events/{event_id}", dependencies=[Depends(verify_api_key)])
+def delete_event(event_id: int, db: Session = Depends(get_db)):
+    db_event = db.query(Event).filter(Event.id == event_id).first()
+    if not db_event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    db.delete(db_event)
+    db.commit()
+    return {"detail": "deleted"}
+
+
+@app.put(
+    "/tags/{tag_id}", response_model=TagRead, dependencies=[Depends(verify_api_key)]
+)
+def update_tag(tag_id: int, tag: TagUpdate, db: Session = Depends(get_db)):
+    db_tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not db_tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    db_tag.name = tag.name
+    db.commit()
+    db.refresh(db_tag)
+    return db_tag
+
+
+@app.delete("/tags/{tag_id}", dependencies=[Depends(verify_api_key)])
+def delete_tag(tag_id: int, db: Session = Depends(get_db)):
+    db_tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not db_tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    db.delete(db_tag)
+    db.commit()
+    return {"detail": "deleted"}

--- a/warcalendar_frontend.jsx
+++ b/warcalendar_frontend.jsx
@@ -138,6 +138,81 @@ export default function CalendarView() {
         <Button onClick={loadEvents}>Фильтровать</Button>
       </div>
 
+      <Card>
+        <CardContent className="space-y-2">
+          <h2 className="font-semibold">Добавить событие</h2>
+          <Input
+            placeholder="API ключ"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+          />
+          <Input
+            placeholder="Название"
+            value={newEvent.title}
+            onChange={(e) =>
+              setNewEvent((prev) => ({ ...prev, title: e.target.value }))
+            }
+          />
+          <Input
+            placeholder="Тип"
+            value={newEvent.type}
+            onChange={(e) =>
+              setNewEvent((prev) => ({ ...prev, type: e.target.value }))
+            }
+          />
+          <Input
+            type="date"
+            placeholder="Начало"
+            value={newEvent.start_date}
+            onChange={(e) =>
+              setNewEvent((prev) => ({ ...prev, start_date: e.target.value }))
+            }
+          />
+          <Input
+            type="date"
+            placeholder="Окончание"
+            value={newEvent.end_date}
+            onChange={(e) =>
+              setNewEvent((prev) => ({ ...prev, end_date: e.target.value }))
+            }
+          />
+          <Input
+            placeholder="Описание"
+            value={newEvent.description}
+            onChange={(e) =>
+              setNewEvent((prev) => ({ ...prev, description: e.target.value }))
+            }
+          />
+          <Input
+            placeholder="URL картинки"
+            value={newEvent.image_url}
+            onChange={(e) =>
+              setNewEvent((prev) => ({ ...prev, image_url: e.target.value }))
+            }
+          />
+          <Input
+            placeholder="Источник"
+            value={newEvent.source_url}
+            onChange={(e) =>
+              setNewEvent((prev) => ({ ...prev, source_url: e.target.value }))
+            }
+          />
+          <div className="flex flex-wrap gap-2">
+            {allTags.map((tag) => (
+              <label key={tag.id} className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={newEvent.tag_ids.includes(tag.id)}
+                  onChange={() => handleTagToggle(tag.id)}
+                />
+                {tag.name}
+              </label>
+            ))}
+          </div>
+          <Button onClick={handleCreateEvent}>Создать</Button>
+        </CardContent>
+      </Card>
+
       <div className="space-y-2">
         <h2 className="text-xl font-bold">Календарь событий</h2>
         <FullCalendar
@@ -151,6 +226,36 @@ export default function CalendarView() {
             url: event.source_url || undefined,
           }))}
         />
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-bold">Список событий</h2>
+        {events.map((event) => (
+          <Card key={event.id}>
+            <CardContent className="flex justify-between items-center">
+              <div>
+                <div className="font-semibold">{event.title}</div>
+                <div className="text-sm">
+                  {format(new Date(event.start_date), "dd.MM.yyyy")} -
+                  {" "}
+                  {format(new Date(event.end_date), "dd.MM.yyyy")}
+                </div>
+              </div>
+              <div className="space-x-2">
+                <Button size="sm" onClick={() => handleEdit(event.id)}>
+                  Редактировать
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => handleDelete(event.id)}
+                >
+                  Удалить
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add update and delete operations to the API
- support fetching individual events
- expose tag update/delete endpoints
- add simple admin form and event list in the frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c6a28b30832aa28b80459678d289