### PR TITLE
Fix: remove unused or_ import

### DIFF
--- a/warcalendar_backend.py
+++ b/warcalendar_backend.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, HTTPException, Depends, Header
-from sqlalchemy import Column, Integer, String, DateTime, Table, ForeignKey, create_engine, and_, or_
+from sqlalchemy import Column, Integer, String, DateTime, Table, ForeignKey, create_engine, and_
 from sqlalchemy.orm import relationship, sessionmaker, declarative_base, Session
 from pydantic import BaseModel
 from datetime import datetime


### PR DESCRIPTION
## Summary
- drop unused `or_` from SQLAlchemy imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d5bdd8c0832aae09788c48ec0caa