### PR TITLE
Extend event model with rewards and countries

### DIFF
--- a/load_test_data.py
+++ b/load_test_data.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from warcalendar_backend import SessionLocal, Base, engine, Event
+
+# Ensure DB tables exist
+Base.metadata.create_all(bind=engine)
+
+events = [
+    {
+        "title": "День НОАК",
+        "type": "Праздник",
+        "start_date": datetime(2023, 8, 1),
+        "end_date": datetime(2023, 8, 1),
+        "rewards": "Декаль, Доступная техника за ЗО",
+        "country_tree": "Китай",
+        "country_holiday": "Китай",
+    },
+    {
+        "title": "День ВДВ РФ",
+        "type": "Праздник",
+        "start_date": datetime(2023, 8, 2),
+        "end_date": datetime(2023, 8, 2),
+        "rewards": "Декаль",
+        "country_tree": "Россия",
+        "country_holiday": "Россия",
+    },
+    {
+        "title": "Первый полет Lightning",
+        "type": "Годовщина",
+        "start_date": datetime(2023, 8, 4),
+        "end_date": datetime(2023, 8, 4),
+        "rewards": "Доступная техника за ЗО",
+        "country_tree": "Великобритания",
+        "country_holiday": None,
+    },
+    {
+        "title": "День ВКС РФ",
+        "type": "Праздник",
+        "start_date": datetime(2023, 8, 12),
+        "end_date": datetime(2023, 8, 12),
+        "rewards": "Декаль",
+        "country_tree": "Россия",
+        "country_holiday": "Россия",
+    },
+    {
+        "title": "Первый полет Tornado",
+        "type": "Годовщина",
+        "start_date": datetime(2023, 8, 14),
+        "end_date": datetime(2023, 8, 14),
+        "rewards": "Декаль, Скидка на доступный набор из магазина",
+        "country_tree": "Великобритания",
+        "country_holiday": None,
+    },
+    {
+        "title": "День ВС Польши",
+        "type": "Праздник",
+        "start_date": datetime(2023, 8, 15),
+        "end_date": datetime(2023, 8, 15),
+        "rewards": "Декаль, Доступная техника за ЗО",
+        "country_tree": "Польша",
+        "country_holiday": "Польша",
+    },
+    {
+        "title": "День ВДВ США",
+        "type": "Праздник",
+        "start_date": datetime(2023, 8, 16),
+        "end_date": datetime(2023, 8, 16),
+        "rewards": "Декаль, Доступная техника за ЗО",
+        "country_tree": "США",
+        "country_holiday": "США",
+    },
+    {
+        "title": "День освобождение Парижа",
+        "type": "Праздник",
+        "start_date": datetime(2023, 8, 19),
+        "end_date": datetime(2023, 8, 19),
+        "rewards": "Декаль",
+        "country_tree": "Франция",
+        "country_holiday": "Франция",
+    },
+    {
+        "title": "Спуск на воду Prinz Eugen",
+        "type": "Годовщина",
+        "start_date": datetime(2023, 8, 22),
+        "end_date": datetime(2023, 8, 22),
+        "rewards": "Доступная техника за ЗО",
+        "country_tree": "Германия",
+        "country_holiday": None,
+    },
+    {
+        "title": "Годовщина принятия МиГ-15 на вооружение",
+        "type": "Годовщина",
+        "start_date": datetime(2023, 8, 23),
+        "end_date": datetime(2023, 8, 23),
+        "rewards": "Доступная техника за ЗО",
+        "country_tree": "СССР",
+        "country_holiday": None,
+    },
+    {
+        "title": "Завершение операции Багратион",
+        "type": "Годовщина",
+        "start_date": datetime(2023, 8, 29),
+        "end_date": datetime(2023, 8, 29),
+        "rewards": "Декаль, Специальный набор в магазине",
+        "country_tree": "СССР",
+        "country_holiday": None,
+    },
+]
+
+session = SessionLocal()
+for data in events:
+    event = Event(**data)
+    session.add(event)
+
+session.commit()
+session.close()
+print("Loaded test data")

--- a/test_api.py
+++ b/test_api.py
@@ -56,6 +56,9 @@ def test_events_endpoint():
             'type': 'type1',
             'start_date': '2023-01-01T00:00:00',
             'end_date': '2023-01-02T00:00:00',
+            'rewards': 'Декаль',
+            'country_tree': 'Testland',
+            'country_holiday': 'Testland',
             'tag_ids': [tag_id],
         },
         headers={'X-API-Key': 'wrong'}
@@ -70,6 +73,9 @@ def test_events_endpoint():
             'type': 'type1',
             'start_date': '2023-01-01T00:00:00',
             'end_date': '2023-01-02T00:00:00',
+            'rewards': 'Декаль',
+            'country_tree': 'Testland',
+            'country_holiday': 'Testland',
             'tag_ids': [tag_id],
         },
         headers={'X-API-Key': backend.API_KEY}
@@ -85,6 +91,18 @@ def test_events_endpoint():
     events = response.json()
     assert len(events) == 1
     assert events[0]['title'] == 'Event 1'
+
+    # Filter by reward
+    response = client.get('/events/?reward=%D0%94%D0%B5%D0%BA%D0%B0%D0%BB%D1%8C')
+    assert response.status_code == 200
+    events = response.json()
+    assert len(events) == 1
+
+    # Filter by country
+    response = client.get('/events/?country=Testland')
+    assert response.status_code == 200
+    events = response.json()
+    assert len(events) == 1
 
 
 def test_nonexistent_object():


### PR DESCRIPTION
## Summary
- add `rewards`, `country_tree` and `country_holiday` fields to `Event`
- support filtering events by reward and country
- expose CRUD endpoints for single event
- add script with sample events
- update API tests for new fields and filters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884fcdea990832aa27a2c5add7b8eec